### PR TITLE
RT#69671 - Fedora version not returned for recent releases

### DIFF
--- a/lib/Linux/Distribution.pm
+++ b/lib/Linux/Distribution.pm
@@ -47,7 +47,7 @@ our %version_match = (
     'gentoo'                => 'Gentoo Base System release (.*)',
     'debian'                => '(.+)',
     'suse'                  => 'VERSION = (.*)',
-    'fedora'                => 'Fedora Core release (\d+) \(',
+    'fedora'                => 'Fedora(?: Core)? release (\d+) \(',
     'redflag'               => 'Red Flag (?:Desktop|Linux) (?:release |\()(.*?)(?: \(.+)?\)',
     'redhat'                => 'Red Hat Linux release (.*) \(',
     'slackware'             => '^Slackware (.+)$',
@@ -195,7 +195,7 @@ This is a simple module that tries to guess on what linux distribution we are ru
 
 It currently recognizes slackware, debian, suse, fedora, redhat, turbolinux, yellowdog, knoppix, mandrake, conectiva, immunix, tinysofa, va-linux, trustix, adamantix, yoper, arch-linux, libranet, gentoo, ubuntu and redflag.
 
-It has function to get the version for debian, suse, redhat, gentoo, slackware, redflag and ubuntu(lsb). People running unsupported distro's are greatly encouraged to submit patches :-)
+It has function to get the version for debian, suse, fedora, redhat, gentoo, slackware, redflag and ubuntu(lsb). People running unsupported distro's are greatly encouraged to submit patches :-)
 
 =head2 EXPORT
 

--- a/t/fedora15.t
+++ b/t/fedora15.t
@@ -1,0 +1,14 @@
+use 5.006000;
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use lib '../lib/';
+use Linux::Distribution;
+
+local $Linux::Distribution::release_files_directory='fedora15/';
+my $linux = Linux::Distribution->new;
+my $distro = $linux->distribution_name();
+is($distro,'fedora');
+my $version = $linux->distribution_version();
+is ($version,'15');

--- a/t/fedora15/fedora-release
+++ b/t/fedora15/fedora-release
@@ -1,0 +1,1 @@
+Fedora release 15 (Lovelock)

--- a/t/fedora15/files
+++ b/t/fedora15/files
@@ -1,0 +1,6 @@
+exists:
+redhat-release
+fedora-release
+do not:
+redhat_version
+lsb-release

--- a/t/fedora15/redhat-release
+++ b/t/fedora15/redhat-release
@@ -1,0 +1,1 @@
+Fedora release 15 (Lovelock)


### PR DESCRIPTION
Dear mister Chorny, here's a pull request for an RT issue. Please consider it for inclusion.

Added patch for RT#69671 - Fedora version not returned for recent releases, kudos tlhackque. Included unit tests.
