### PR TITLE
Handle fields in lsb-release being quoted

### DIFF
--- a/lib/Linux/Distribution.pm
+++ b/lib/Linux/Distribution.pm
@@ -138,7 +138,7 @@ sub _get_lsb_info {
     my $tmp = $self->{'release_file'};
     if ( -r "$release_files_directory/" . $standard_release_file ) {
         $self->{'release_file'} = $standard_release_file;
-        $self->{'pattern'} = $field . '=(?:")?(.+)(?:")?';
+        $self->{'pattern'} = $field . '=(?:")?(.+?)(?:")?';
         my $info = $self->_get_file_info();
         if ($info){
             $self->{$field} = $info;

--- a/lib/Linux/Distribution.pm
+++ b/lib/Linux/Distribution.pm
@@ -138,7 +138,7 @@ sub _get_lsb_info {
     my $tmp = $self->{'release_file'};
     if ( -r "$release_files_directory/" . $standard_release_file ) {
         $self->{'release_file'} = $standard_release_file;
-        $self->{'pattern'} = $field . '=(.+)';
+        $self->{'pattern'} = $field . '=(?:")?(.+)(?:")?';
         my $info = $self->_get_file_info();
         if ($info){
             $self->{$field} = $info;

--- a/lib/Linux/Distribution.pm
+++ b/lib/Linux/Distribution.pm
@@ -138,7 +138,7 @@ sub _get_lsb_info {
     my $tmp = $self->{'release_file'};
     if ( -r "$release_files_directory/" . $standard_release_file ) {
         $self->{'release_file'} = $standard_release_file;
-        $self->{'pattern'} = $field . '=(?:")?(.+?)(?:")?';
+        $self->{'pattern'} = $field . '=(?:")?([^"]+)(?:")?';
         my $info = $self->_get_file_info();
         if ($info){
             $self->{$field} = $info;


### PR DESCRIPTION
Some distributions will quote fields in their lsb-release file.  The
spec doesn't seem to choose either way, so handle the quotes correctly
if they're there.

(Gentoo does this; other distributions might, too)