### PR TITLE
Split out version detection for 'suse' to 'sles' and 'opensuse'.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 * 2013-??-?? version 0.22
 
+Split out version detection for 'suse' to 'sles' and 'opensuse'
 Added OS and version detection for Amazon Linux. (RT#88412)
 
 * 2011-02-23 version 0.21

--- a/lib/Linux/Distribution.pm
+++ b/lib/Linux/Distribution.pm
@@ -58,6 +58,8 @@ our %version_match = (
     'pardus'                => '^Pardus (.+)$',
     'centos'                => '^CentOS(?: Linux)? release (.+)(?:\s\(Final\))',
     'scientific'            => '^Scientific Linux release (.+) \(',
+    'opensuse'              => '^openSUSE (.+) \(',
+    'sles'                  => 'SUSE Linux Enterprise Server (.+) \(',
     'amazon'                => 'Amazon Linux AMI release (.+)$',
 );
 
@@ -106,6 +108,18 @@ sub distribution_name {
                         $self->{'release_file'}='redhat-release';
                         if ( $self->_get_file_info() ) {
                             $self->{'DISTRIB_ID'} = $rhel_deriv;
+                            $self->{'release_file'} = $_;
+                            return $self->{'DISTRIB_ID'};
+                        }
+                    }
+                    $self->{'pattern'}='';
+                }
+                elsif ( $release_files{$_} eq 'suse' ) {
+                    foreach my $suse_deriv ('opensuse','sles') {
+                        $self->{'pattern'} = $version_match{$suse_deriv};
+                        $self->{'release_file'}='SuSE-release';
+                        if ( $self->_get_file_info() ) {
+                            $self->{'DISTRIB_ID'} = $suse_deriv;
                             $self->{'release_file'} = $_;
                             return $self->{'DISTRIB_ID'};
                         }

--- a/t/opensuse.t
+++ b/t/opensuse.t
@@ -1,0 +1,14 @@
+use 5.006000;
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use lib '../lib/';
+use Linux::Distribution;
+
+local $Linux::Distribution::release_files_directory='t/opensuse/';
+my $linux = Linux::Distribution->new;
+my $distro = $linux->distribution_name();
+is($distro,'opensuse');
+my $version = $linux->distribution_version();
+is ($version,'12.3');

--- a/t/opensuse/SuSE-release
+++ b/t/opensuse/SuSE-release
@@ -1,0 +1,3 @@
+openSUSE 12.3 (x86_64)
+VERSION = 12.3
+CODENAME = Dartmouth

--- a/t/opensuse/files
+++ b/t/opensuse/files
@@ -1,0 +1,5 @@
+exists:
+SuSE-release
+do not:
+redhat_version
+lsb-release

--- a/t/sles.t
+++ b/t/sles.t
@@ -1,0 +1,14 @@
+use 5.006000;
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use lib '../lib/';
+use Linux::Distribution;
+
+local $Linux::Distribution::release_files_directory='t/sles/';
+my $linux = Linux::Distribution->new;
+my $distro = $linux->distribution_name();
+is($distro,'sles');
+my $version = $linux->distribution_version();
+is ($version,'11');

--- a/t/sles/SuSE-release
+++ b/t/sles/SuSE-release
@@ -1,0 +1,3 @@
+SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 3

--- a/t/sles/files
+++ b/t/sles/files
@@ -1,0 +1,5 @@
+exists:
+SuSE-release
+do not:
+redhat_version
+lsb-release


### PR DESCRIPTION
Hi Alex,

Until now SUSE Linux Enterprise (SLES) and openSUSE both reported as 'suse'. However I needed to distinguish between the two. Attached is the patch + tests that implements this. Of course this does 'break' people who might expect these distros to report in as 'suse' - I am not sure how to handle this. Do you care about this possible 'breakage'? of course reporting 'sles' and 'opensuse' is arguably more correct. 
